### PR TITLE
Add Functionality from pc-fwmanager into sysadm-firewall

### DIFF
--- a/src/library/library.pro
+++ b/src/library/library.pro
@@ -1,4 +1,4 @@
-
+CONFIG   += c++11
 QT       += core network
 
 TARGET=sysadm

--- a/src/library/sysadm-firewall.cpp
+++ b/src/library/sysadm-firewall.cpp
@@ -84,9 +84,27 @@ void Firewall::OpenPort(int port, QString type)
     SaveOpenPorts();
 }
 
+void Firewall::OpenPort(QVector<PortInfo> ports)
+{
+    for(PortInfo port : ports)
+    {
+        openports.append(port);
+    }
+    SaveOpenPorts();
+}
+
 void Firewall::ClosePort(int port, QString type)
 {
     openports.removeAll(LookUpPort(port,type));
+    SaveOpenPorts();
+}
+
+void Firewall::ClosePort(QVector<PortInfo> ports)
+{
+    for(PortInfo port : ports)
+    {
+        openports.removeAll(port);
+    }
     SaveOpenPorts();
 }
 

--- a/src/library/sysadm-firewall.cpp
+++ b/src/library/sysadm-firewall.cpp
@@ -1,3 +1,9 @@
+//===========================================
+//  PC-BSD source code
+//  Copyright (c) 2015, PC-BSD Software/iXsystems
+//  Available under the 3-clause BSD license
+//  See the LICENSE file for full details
+
 #include "sysadm-firewall.h"
 #include <QtCore>
 using namespace sysadm;

--- a/src/library/sysadm-firewall.cpp
+++ b/src/library/sysadm-firewall.cpp
@@ -129,6 +129,15 @@ void Firewall::Restart()
     system("/etc/rc.d/ipfw restart");
 }
 
+void Firewall::RestoreDefaults()
+{
+    //move the files out of the way
+    system("mv /etc/ipfw.rules /etc/ipfw.rules.previous");
+    system("mv /etc/ipfw.openports /etc/ipfw.openports.previous");
+    //refresh/restart the rules files
+    system("sh /usr/local/share/pcbsd/scripts/reset-firewall");
+}
+
 Firewall::Firewall()
 {    
     readServicesFile();

--- a/src/library/sysadm-firewall.cpp
+++ b/src/library/sysadm-firewall.cpp
@@ -10,10 +10,10 @@
 #include <tuple>
 
 using namespace sysadm;
-PortInfo Firewall::LookUpPort(int portNumber, QString portType)
+PortInfo Firewall::LookUpPort(int port, QString type)
 {
     //Make sure that the port is valid
-    if (portNumber < 0 || portNumber > 65535)
+    if (port < 0 || port > 65535)
     {
         PortInfo returnValue;
         returnValue.Port = -1;
@@ -28,19 +28,19 @@ PortInfo Firewall::LookUpPort(int portNumber, QString portType)
 
     PortInfo returnValue;
     //the port number is valid so set it
-    returnValue.Port = portNumber;
+    returnValue.Port = port;
 
     //make sure that the portType is cased in lower to match the service file and
     //then store it in the returnValue, since there isn't a huge point in checking
     //the validitiy of the type since /etc/services lists more than udp/tcp
-    portType = portType.toLower();
-    returnValue.PortType =  portType;
+    type = type.toLower();
+    returnValue.Type =  type;
 
     //Check to see if it's a recommended port
     returnValue.Recommended = false;
     for(int i = 0; i < recommendedPortsSize; i++)
     {
-        if (portNumber == recommendedPorts[i])
+        if (port == recommendedPorts[i])
         {
             returnValue.Recommended = true;
         }
@@ -49,12 +49,12 @@ PortInfo Firewall::LookUpPort(int portNumber, QString portType)
    //Check to see if the port number is listed. The format in the file
    // is portname/portType. ex.: 22/tcp
 
-   QStringList port = portStrings->filter(QString::number(portNumber) + "/" + portType);
-   if(port.size() > 0)
+   QStringList portList = portStrings->filter(QString::number(port) + "/" + type);
+   if(portList.size() > 0)
    {
        //grab the first one, there may be duplicates due to colliding ports in the /etc/services file
        //but those are listed after the declaration for what the port officially should be used for
-       QString line = port.at(0);
+       QString line = portList.at(0);
 
        //Split across spaces since it's whitespace delimited
        QStringList lineList = line.split(' ');
@@ -196,7 +196,7 @@ void Firewall::SaveOpenPorts()
       QStringList fileout;
       for(int i=0; i<openports.length(); i++){
         fileout.append("#" + openports[i].Keyword + ": " + openports[i].Description + "\n" +
-                   openports[i].PortType +" "+QString::number(openports[i].Port));
+                   openports[i].Type +" "+QString::number(openports[i].Port));
       }
       //Always make sure that the file always ends with a newline
       if(!fileout.isEmpty()){ fileout << ""; }

--- a/src/library/sysadm-firewall.cpp
+++ b/src/library/sysadm-firewall.cpp
@@ -7,7 +7,6 @@
 #include "sysadm-firewall.h"
 #include <QtCore>
 #include <algorithm>
-#include <tuple>
 
 using namespace sysadm;
 PortInfo Firewall::LookUpPort(int port, QString type)

--- a/src/library/sysadm-firewall.cpp
+++ b/src/library/sysadm-firewall.cpp
@@ -37,9 +37,9 @@ PortInfo Firewall::LookUpPort(int port, QString type)
 
     //Check to see if it's a recommended port
     returnValue.Recommended = false;
-    for(int i = 0; i < recommendedPortsSize; i++)
+    for(int recommendedPort : recommendedPorts)
     {
-        if (port == recommendedPorts[i])
+        if (port == recommendedPort)
         {
             returnValue.Recommended = true;
         }
@@ -151,6 +151,8 @@ void Firewall::RestoreDefaults()
     system("mv /etc/ipfw.openports /etc/ipfw.openports.previous");
     //refresh/restart the rules files
     system("sh /usr/local/share/pcbsd/scripts/reset-firewall");
+
+    LoadOpenPorts();
 }
 
 Firewall::Firewall()
@@ -211,9 +213,9 @@ void Firewall::SaveOpenPorts()
     //Convert to file format
       std::sort(openports.begin(), openports.end()); //make sure they are still sorted by port
       QStringList fileout;
-      for(int i=0; i<openports.length(); i++){
-        fileout.append("#" + openports[i].Keyword + ": " + openports[i].Description + "\n" +
-                   openports[i].Type +" "+QString::number(openports[i].Port));
+      for(PortInfo port : openports){
+        fileout.append("#" + port.Keyword + ": " + port.Description + "\n" +
+                   port.Type +" "+QString::number(port.Port));
       }
       //Always make sure that the file always ends with a newline
       if(!fileout.isEmpty()){ fileout << ""; }

--- a/src/library/sysadm-firewall.h
+++ b/src/library/sysadm-firewall.h
@@ -7,6 +7,7 @@
 #ifndef PORTLOOKUP_H
 #define PORTLOOKUP_H
 #include <QtCore>
+#include <tuple>
 namespace sysadm
 {
 struct PortInfo{

--- a/src/library/sysadm-firewall.h
+++ b/src/library/sysadm-firewall.h
@@ -55,11 +55,23 @@ public:
     void OpenPort(int number, QString type);
 
     /**
+     * @brief Opens a set of ports
+     * @param ports a vector of ports to open
+     */
+    void OpenPort(QVector<PortInfo> ports);
+
+    /**
      * @brief ClosePort closes a port
      * @param number a port number between 0 and 2^16 -1
      * @param type specify whether the port is tdp, udp, etc
      */
     void ClosePort(int number, QString type);
+
+    /**
+     * @brief ClosePort closes a set of ports
+     * @param ports a vector of ports to close
+     */
+    void ClosePort(QVector<PortInfo> ports);
 
     /**
      * @brief finds a list of ports that are open gets the info about them

--- a/src/library/sysadm-firewall.h
+++ b/src/library/sysadm-firewall.h
@@ -29,8 +29,7 @@ struct PortInfo{
     {   return !(lhs == rhs);}
 };
 
-const static int recommendedPorts[] = {22, 80};
-const static int recommendedPortsSize = 2;
+const static QVector<int> recommendedPorts = {22, 80};
 class Firewall
 {
 

--- a/src/library/sysadm-firewall.h
+++ b/src/library/sysadm-firewall.h
@@ -15,6 +15,17 @@ struct PortInfo{
     QString Keyword;
     QString Description;
     bool Recommended;
+    friend bool operator<(const PortInfo lhs, const PortInfo rhs){
+        return std::tie(lhs.Port,lhs.PortType) < std::tie(rhs.Port,rhs.PortType);
+    }
+    friend bool operator>(const PortInfo lhs, const PortInfo rhs)
+    {   return rhs < lhs;}
+    friend bool operator==(const PortInfo lhs, const PortInfo rhs)
+    {
+        return lhs.Port == rhs.Port && lhs.PortType == rhs.PortType;
+    }
+    friend bool operator !=(const PortInfo lhs, const PortInfo rhs)
+    {   return !(lhs == rhs);}
 };
 
 const static int recommendedPorts[] = {22, 80};
@@ -91,7 +102,7 @@ private:
     void readServicesFile();
     QStringList* portStrings;
 
-    QStringList openports;
+    QVector<PortInfo> openports;
 
     void LoadOpenPorts();
     void SaveOpenPorts();

--- a/src/library/sysadm-firewall.h
+++ b/src/library/sysadm-firewall.h
@@ -11,18 +11,18 @@ namespace sysadm
 {
 struct PortInfo{
     int Port;
-    QString PortType;
+    QString Type;
     QString Keyword;
     QString Description;
     bool Recommended;
     friend bool operator<(const PortInfo lhs, const PortInfo rhs){
-        return std::tie(lhs.Port,lhs.PortType) < std::tie(rhs.Port,rhs.PortType);
+        return std::tie(lhs.Port,lhs.Type) < std::tie(rhs.Port,rhs.Type);
     }
     friend bool operator>(const PortInfo lhs, const PortInfo rhs)
     {   return rhs < lhs;}
     friend bool operator==(const PortInfo lhs, const PortInfo rhs)
     {
-        return lhs.Port == rhs.Port && lhs.PortType == rhs.PortType;
+        return lhs.Port == rhs.Port && lhs.Type == rhs.Type;
     }
     friend bool operator !=(const PortInfo lhs, const PortInfo rhs)
     {   return !(lhs == rhs);}
@@ -40,25 +40,25 @@ public:
      * including its port type, keyword, description, and whether it's a
      * recommended port
      *
-     * @param portNumber a port number between 0 and 2^16 - 1
-     * @param portType specify whether the port is tdp, udp, etc
+     * @param number a port number between 0 and 2^16 - 1
+     * @param type specify whether the port is tdp, udp, etc
      *
      * @ErrorConditions Port Number is set to -1 and a description of the error is stored in the description variable
      */
-    PortInfo LookUpPort(int portNumber, QString portType);
+    PortInfo LookUpPort(int number, QString type);
     /**
      * @brief Opens a port
-     * @param portNumber a port number between 0 and 2^16 -1
-     * @param portType specify whether the port is tdp, udp, etc
+     * @param number a port number between 0 and 2^16 -1
+     * @param type specify whether the port is tdp, udp, etc
      */
-    void OpenPort(int portNumber, QString portType);
+    void OpenPort(int number, QString type);
 
     /**
      * @brief ClosePort closes a port
-     * @param portNumber a port number between 0 and 2^16 -1
-     * @param portType specify whether the port is tdp, udp, etc
+     * @param number a port number between 0 and 2^16 -1
+     * @param type specify whether the port is tdp, udp, etc
      */
-    void ClosePort(int portNumber, QString portType);
+    void ClosePort(int number, QString type);
 
     /**
      * @brief finds a list of ports that are open gets the info about them

--- a/src/library/sysadm-firewall.h
+++ b/src/library/sysadm-firewall.h
@@ -23,22 +23,74 @@ class Firewall
 {
 
 public:
+    ///#section: port commands
     /**
      * @description Returns a structure containing information about the port
      * including its port type, keyword, description, and whether it's a
      * recommended port
      *
-     * @parameter portNumber a port number between 0 and 2^16 - 1
+     * @param portNumber a port number between 0 and 2^16 - 1
+     * @param portType specify whether the port is tdp, udp, etc
      *
      * @ErrorConditions Port Number is set to -1 and a description of the error is stored in the description variable
      */
     PortInfo LookUpPort(int portNumber, QString portType);
+    /**
+     * @brief Opens a port
+     * @param portNumber a port number between 0 and 2^16 -1
+     * @param portType specify whether the port is tdp, udp, etc
+     */
+    void OpenPort(int portNumber, QString portType);
+
+    /**
+     * @brief ClosePort closes a port
+     * @param portNumber a port number between 0 and 2^16 -1
+     * @param portType specify whether the port is tdp, udp, etc
+     */
+    void ClosePort(int portNumber, QString portType);
+
+    /**
+     * @brief finds a list of ports that are open gets the info about them
+     * and returns them
+     * @return a QVector of the open ports
+     */
+    QVector<PortInfo> OpenPorts();
+
+    ///#endsection
+
+    ///#section: firewall commands
+    /**
+     * @brief Checks to see if the firewall is running
+     * @return true if the firewall is running, false if not
+     */
+    bool IsRunning();
+    /**
+     * @brief Starts the firewall
+     */
+    void Start();
+    /**
+     * @brief Stops the firewall
+     */
+    void Stop();
+    /**
+     * @brief Restarts the firewall
+     */
+    void Restart();
+    ///#endsection
+
+    ///#section: ctors dtors
     Firewall();
     ~Firewall();
+    ///#endsection
 
 private:
     void readServicesFile();
     QStringList* portStrings;
+
+    QStringList openports;
+
+    void LoadOpenPorts();
+    void SaveOpenPorts();
 };
 }
 #endif // PORTLOOKUP_H

--- a/src/library/sysadm-firewall.h
+++ b/src/library/sysadm-firewall.h
@@ -55,7 +55,6 @@ public:
      * @return a QVector of the open ports
      */
     QVector<PortInfo> OpenPorts();
-
     ///#endsection
 
     ///#section: firewall commands
@@ -76,6 +75,11 @@ public:
      * @brief Restarts the firewall
      */
     void Restart();
+
+    /**
+     * @brief Restores the Default Configuration
+     */
+    void RestoreDefaults();
     ///#endsection
 
     ///#section: ctors dtors


### PR DESCRIPTION
Pulls in the following functionality from pc-fwmanager:
*Open/Close Ports
*Get a list of open ports (modified to return a QVector that contains a list of PortInfo)
*Start/Stop/Restart the Firewall and query if the Firewall is running
*Restore Default configuration
