### PR TITLE
Move system() calls over to their equivalents from sysadm-general.

### DIFF
--- a/src/library/sysadm-firewall.h
+++ b/src/library/sysadm-firewall.h
@@ -98,7 +98,14 @@ public:
      * @brief Restarts the firewall
      */
     void Restart();
-
+    /**
+     * @brief Enables the firewall in rc.conf, Start() will automatically enable the firewall
+     */
+    void Enable();
+    /**
+     * @brief Disables the firewall in rc.conf use after Stop() to completely disable
+     */
+    void Disable();
     /**
      * @brief Restores the Default Configuration
      */


### PR DESCRIPTION
as the title says, system calls are moved over, I do think it would probably be a good idea for sysadm-general to have an API for changing rc.conf as it seems like something that would be reimplemented a lot in the future otherwise.
