### PR TITLE
 	Content addition to the SysAdm server docs

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -1,0 +1,55 @@
+.. _gettingstarted:
+
+Getting Started
+===============
+
+Beginning with SysAdm is a relatively simple process. 
+SysAdm files are currently available from the `github repository <https://github.com/pcbsd/sysadm.git>`_
+
+
+.. _building:
+
+Building SysAdm
+---------------
+
+The following Qt Modules are required before attempting to build SysAdm: ::
+
+  Qt5 Core (# pkg install qt5-core)
+  Qt5 Concurrent (# pkg install qt5-concurrent)
+  Qt5 Network (# pkg install qt-network)
+  Qt5 Sql (# pkg install qt5-sql)
+  Qt5 Websockets (# pkg install qt5-websockets)
+
+Building the prototype version of SysAdm assumes you have access to github.com. ::
+
+  % git clone https://github.com/pcbsd/sysadm.git
+  % cd sysadm/src
+  % /usr/local/lib/qt5/bin/qmake -recursive
+  % make && sudo make install
+
+.. _starting:
+
+Starting SysAdm
+---------------
+
+SysAdm has two functioning states, WebSockets (preferred) and REST.
+Websockets allow the client to stay connected over a long period of time, allowing the usage of notifications and events.
+The REST server mode is more limited as it only allows the user to send and receive single messages over a short term connection.
+Please note that it is possible to enable SysAdm to function in both states simultaneously. ::
+  
+  (Websocket - recommended)
+  % sudo sysrc -f /etc/rc.conf sysadm_enable="YES"
+  % sudo service sysadm start
+
+  (Optional for REST)
+  % sudo sysrc -f /etc/rc.conf sysadm_rest_enable="YES"
+  % sudo service sysadm-rest start
+
+
+.. _adddoc:
+
+Additional Documentation
+------------------------
+
+API documentation can be found at https://api.pcbsd.org .
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,8 @@ Contents:
    :maxdepth: 4
 
    introduction
+   basics
+   manage
 
 Indices and tables
 ==================

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -1,3 +1,6 @@
+
+.. _intro:
+
 Introduction
 ============
 
@@ -9,4 +12,9 @@ Version |version|
 
 Copyright © 2016 iXSystems®.
 
-Welcome to SysAdm®!
+.. Intro Text WIP
+Welcome to SysAdm®! This documentation is intended to educate the user on initializing and managing SysAdm.
+Initialization and management will be documented in two separate chapters, :ref:`gettingstarted`, and :ref:`management`.
+API documentation is being handled at https://api.pcbsd.org.
+
+

--- a/docs/manage.rst
+++ b/docs/manage.rst
@@ -1,0 +1,8 @@
+.. _management:
+
+SysAdm Management
+=================
+
+.. WIP
+
+<insert text here>

--- a/docs/manage.rst
+++ b/docs/manage.rst
@@ -3,6 +3,28 @@
 SysAdm Management
 =================
 
-.. WIP
+SysAdm comes with a standard configuration file located at :file:`/usr/local/etc/sysadm.conf.dist`.
+  
+It is possible to edit this file for a custom configuration, but the result will need to be saved as :kbd:`sysadm.conf`.
+Here is the current default settings for SysAdm::
 
-<insert text here>
+  #Sample Configuration file for the sysadm server
+
+  ### Server Port Number ###
+  # - Websocket Server (standard)
+  PORT=12150
+  # - REST Server (started with the "-rest" CLI flag)
+  PORT_REST=12151
+  
+This default configuration also has blacklist options, recreated here::
+
+  ### Blacklist options ###
+  # - Number of minutes that an IP remains on the blacklist
+  BLACKLIST_BLOCK_MINUTES=60
+  # - Number of authorization failures before an IP is placed on the blacklist
+  BLACKLIST_AUTH_FAIL_LIMIT=5
+  # - Number of minutes of no activity from an IP before  resetting the failure counter
+  #   (Note: A successful authorization will always reset the fail counter)
+  BLACKLIST_AUTH_FAIL_RESET_MINUTES=10
+  
+Please note these default options are subject to change as the SysAdm utility is developed.


### PR DESCRIPTION
- Added two new files: one for installation instructions, and one for server management and commands which is empty for the moment.
- Added more descriptive text and proper links to API documentation.
