### PR TITLE
Convert manifests from relaunchd to jobd

### DIFF
--- a/src/daemons.d/org.pcbsd.sysadm-rest.json.dist
+++ b/src/daemons.d/org.pcbsd.sysadm-rest.json.dist
@@ -1,5 +1,0 @@
-{
-	"Label": "org.pcbsd.sysadm-rest",
-	"ProgramArguments": [ "/usr/local/bin/sysadm-server", "-rest" ],
-	"RunAtLoad": false
-}

--- a/src/daemons.d/org.pcbsd.sysadm.json.dist
+++ b/src/daemons.d/org.pcbsd.sysadm.json.dist
@@ -1,5 +1,0 @@
-{
-	"Label": "org.pcbsd.sysadm",
-	"Program": "/usr/local/bin/sysadm-server",
-	"RunAtLoad": true
-}

--- a/src/job.d/org.pcbsd.sysadm-rest.json
+++ b/src/job.d/org.pcbsd.sysadm-rest.json
@@ -1,0 +1,5 @@
+{
+	"Label": "org.pcbsd.sysadm-rest",
+	"Program": [ "/usr/local/bin/sysadm-server", "-rest" ],
+	"Enable": false
+}

--- a/src/job.d/org.pcbsd.sysadm.json
+++ b/src/job.d/org.pcbsd.sysadm.json
@@ -1,0 +1,5 @@
+{
+	"Label": "org.pcbsd.sysadm",
+	"Program": ["/usr/local/bin/sysadm-server"],
+	"Enable": true
+}

--- a/src/sysadm.pro
+++ b/src/sysadm.pro
@@ -9,10 +9,10 @@ rcd.extra = cp rc.d/* $(INSTALL_ROOT)/usr/local/etc/rc.d/
 dconf.path = /usr/local/etc/job.d/
 dconf.extra = cp job.d/* $(INSTALL_ROOT)/usr/local/etc/job.d/
 
-wsdaemon.path = /usr/local/share/job.d/
+wsdaemon.path = /usr/local/etc/job.d/
 wsdaemon.extra = cp job.d/org.pcbsd.sysadm.json $(INSTALL_ROOT)/usr/local/etc/job.d/org.pcbsd.sysadm.json
--
-rstdaemon.path = /usr/local/share/launchd/daemons/
+
+rstdaemon.path = /usr/local/etc/job.d/
 rstdaemon.extra = cp job.d/org.pcbsd.sysadm-rest.json $(INSTALL_ROOT)/usr/local/etc/job.d/org.pcbsd.sysadm-rest.json
 
 conf.path = /usr/local/etc/

--- a/src/sysadm.pro
+++ b/src/sysadm.pro
@@ -6,14 +6,14 @@ SUBDIRS+= server bridge
 rcd.path = /usr/local/etc/rc.d/
 rcd.extra = cp rc.d/* $(INSTALL_ROOT)/usr/local/etc/rc.d/
 
-dconf.path = /usr/local/etc/launchd/daemons/
-dconf.extra = cp daemons.d/* $(INSTALL_ROOT)/usr/local/etc/launchd/daemons/
+dconf.path = /usr/local/etc/job.d/
+dconf.extra = cp job.d/* $(INSTALL_ROOT)/usr/local/etc/job.d/
 
-wsdaemon.path = /usr/local/share/launchd/daemons/
-wsdaemon.extra = cp daemons.d/org.pcbsd.sysadm.json.dist $(INSTALL_ROOT)/usr/local/share/launchd/daemons/org.pcbsd.sysadm.json
-
+wsdaemon.path = /usr/local/share/job.d/
+wsdaemon.extra = cp job.d/org.pcbsd.sysadm.json $(INSTALL_ROOT)/usr/local/etc/job.d/org.pcbsd.sysadm.json
+-
 rstdaemon.path = /usr/local/share/launchd/daemons/
-rstdaemon.extra = cp daemons.d/org.pcbsd.sysadm-rest.json.dist $(INSTALL_ROOT)/usr/local/share/launchd/daemons/org.pcbsd.sysadm-rest.json
+rstdaemon.extra = cp job.d/org.pcbsd.sysadm-rest.json $(INSTALL_ROOT)/usr/local/etc/job.d/org.pcbsd.sysadm-rest.json
 
 conf.path = /usr/local/etc/
 conf.extra = cp conf/sysadm.conf ${INSTALL_ROOT}/usr/local/etc/sysadm.conf.dist


### PR DESCRIPTION
jobd 0.7 uses different paths and syntax from relaunchd. This has been tested on my workstation:

```
# jobctl list                  
Label                    Status
------------------------------------------------------------------------
org.pcbsd.sysadm         {"Enabled":true,"FaultState":"online","Pid":26433,"State":"running"}
org.pcbsd.sysadm-rest    {"Enabled":false,"FaultState":"online","Pid":0,"State":"loaded"}
```
