### PR TITLE
Initial whack at making service manager understand openrc

### DIFF
--- a/src/server/library/sysadm-servicemanager.h
+++ b/src/server/library/sysadm-servicemanager.h
@@ -12,6 +12,9 @@ struct Service{
         Name = "";
         Tag = "";
         Directory = "";
+	Path = "";
+	Description = "";
+	Runlevel = "";
     }
 
     QString Name;
@@ -19,6 +22,7 @@ struct Service{
     QString Directory;
     QString Path;
     QString Description;
+    QString Runlevel;
 };
 
 class ServiceManager
@@ -79,9 +83,16 @@ private:
     QList<Service> services;
     Service loadServices(QString service = ""); //Return struct is optional - only used for a single service search
 
-    QHash<QString, QString> rcdata; //rc.conf settings
+    QHash<QString, QString> rcdata; //output of rc-status
     void loadRCdata();
 
+    QHash<QString, QString> unuseddata;
+    void loadUnusedData();
+
+    void loadRunlevels();
+
+    bool enableDisableService(QString name, bool enable=false);
+    
     QString chroot;
     QString ip;
 };


### PR DESCRIPTION
Conversion of sysadm-servicemanager to understand openrc instead of looking at r.conf.
A lot of the conversion was use of rc-status command to list of services, their status, enabled services, runlevels, "enabled at boot" status.
If a service was already enabled at boot, that runlevel is used for any rc-update commands, otherwise it defaults to runlevel of "default".
Built and ran binary locally, used unmodified sysadm client to look at service list, enable/disable a service and start/stop a service.
The existing OpenRC scripts are inconsistent with "description".  Some use "name=" for the description, others "description=" so the initial parsing in loadServices() looks for different things to find the description.
Let me know what you don't like.